### PR TITLE
Added support for phpro/grumphp v0.18.0 and higher

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "phpro/grumphp": "~0.10",
-        "mcmatters/fqn-checker": "~1.0.2"
+        "mcmatters/fqn-checker": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/readme.md
+++ b/readme.md
@@ -11,13 +11,12 @@ composer require mcmatters/grumphp-fqn-checker
 Add next lines to your `grumphp.yml`:
 
 ```yaml
-parameters:
+grumphp:
     tasks:
       fqn_checker: ~
 
 services:
-  task.fqn_checker:
-    class: McMatters\Grumphp\FqnChecker\FqnCheckerTask
-    tags:
-      - {name: grumphp.task, config: fqn_checker}
+    McMatters\Grumphp\FqnChecker\FqnCheckerTask:
+        tags:
+            - { name: grumphp.task, task: fqn_checker }
 ```

--- a/src/FqnCheckerFormatter.php
+++ b/src/FqnCheckerFormatter.php
@@ -45,7 +45,7 @@ class FqnCheckerFormatter
     protected function getMessage(): string
     {
         $messages = [];
-        $headers = ['Function', 'Lines'];
+        $headers = ['Unimported', 'Lines'];
         $buffer = new BufferedOutput();
 
         foreach ($this->errors as $file => $fileErrors) {
@@ -86,7 +86,7 @@ class FqnCheckerFormatter
      */
     protected function getHeading(): string
     {
-        $message = 'Used unimported functions';
+        $message = 'Used unimported functions or/and constants';
 
         $wrap = str_repeat('*', strlen($message) + 12);
 

--- a/src/FqnCheckerTask.php
+++ b/src/FqnCheckerTask.php
@@ -100,13 +100,14 @@ class FqnCheckerTask implements TaskInterface
         $output = new BufferedOutput();
 
         $app = new Application();
+        $app->setAutoExit(false);
         $app->add(new RunCommand());
 
         /** @var SplFileInfo $file */
         foreach ($files as $file) {
             $input = new ArrayInput([
                 'command' => 'fqn-checker:check',
-                'path' => $file->getPath(),
+                'path' => $file->getRealPath(),
             ]);
 
             $app->run($input, $output);

--- a/src/FqnCheckerTask.php
+++ b/src/FqnCheckerTask.php
@@ -7,6 +7,7 @@ namespace McMatters\Grumphp\FqnChecker;
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\TaskConfigInterface;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -28,27 +29,37 @@ use function implode;
 class FqnCheckerTask implements TaskInterface
 {
     /**
-     * @return string
+     * @var TaskConfigInterface
      */
-    public function getName(): string
-    {
-        return 'fqn_checker';
-    }
-
-    /**
-     * @return array
-     */
-    public function getConfiguration(): array
-    {
-        return [];
-    }
+    private $config;
 
     /**
      * @return OptionsResolver
      */
-    public function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): OptionsResolver
     {
         return new OptionsResolver();
+    }
+
+    /**
+     * @param \GrumPHP\Task\Config\TaskConfigInterface $config
+     *
+     * @return $this|\GrumPHP\Task\TaskInterface
+     */
+    public function withConfig(TaskConfigInterface $config): TaskInterface
+    {
+        $new = clone $this;
+        $new->config = $config;
+
+        return $new;
+    }
+
+    /**
+     * @return \GrumPHP\Task\Config\TaskConfigInterface
+     */
+    public function getConfig(): TaskConfigInterface
+    {
+        return $this->config;
     }
 
     /**
@@ -62,9 +73,10 @@ class FqnCheckerTask implements TaskInterface
     }
 
     /**
-     * @param ContextInterface $context
+     * @param \GrumPHP\Task\Context\ContextInterface $context
      *
-     * @return TaskResultInterface
+     * @return \GrumPHP\Runner\TaskResultInterface
+     * @throws \Exception
      */
     public function run(ContextInterface $context): TaskResultInterface
     {
@@ -86,9 +98,10 @@ class FqnCheckerTask implements TaskInterface
     }
 
     /**
-     * @param FilesCollection $files
+     * @param \GrumPHP\Collection\FilesCollection $files
      *
      * @return array
+     * @throws \Exception
      */
     protected function getErrors(FilesCollection $files): array
     {


### PR DESCRIPTION
Changed the way of using the config according to the changes in phpro/grumphp v0.18.0+. Changed the description with an example of how to add MCMatters/grumphp-fqn-checker as a task to be running with grumphp.